### PR TITLE
Add adventure, battle, boss, and raid gameplay systems

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,6 +68,7 @@ model User {
   vcoins      Int       @default(100)
   xp          Int       @default(0)
   level       Int       @default(1)
+  skillPoints Int       @default(0)
   lastDailyAt DateTime?
 
   healthMax  Int       @default(100)
@@ -78,6 +79,11 @@ model User {
   lastHealAt DateTime?
   deaths     Int       @default(0)
 
+  strength  Int @default(1)
+  agility   Int @default(1)
+  intellect Int @default(1)
+  luck      Int @default(1)
+
   equippedPickaxeId Int?
   equippedRodId     Int?
   equippedWeaponId  Int?
@@ -86,6 +92,8 @@ model User {
   metadata Json?
 
   items UserItem[]
+  bossDamages BossDamage[]
+  raidMembers RaidMember[]
 }
 
 model Item {
@@ -264,4 +272,56 @@ model LocationEncounter {
   monster  Monster  @relation(fields: [monsterId], references: [id], onDelete: Cascade)
 
   @@unique([locationId, monsterId])
+}
+
+model Boss {
+  id            Int      @id @default(autoincrement())
+  name          String
+  rotationWeek  Int      @unique
+  hp            Int
+  maxHp         Int
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  metadata      Json?
+
+  damages BossDamage[]
+}
+
+model BossDamage {
+  id           Int      @id @default(autoincrement())
+  bossId       Int
+  userId       String
+  damage       Int      @default(0)
+  lastAttackAt DateTime @default(now())
+
+  boss Boss @relation(fields: [bossId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([bossId, userId])
+}
+
+model Raid {
+  id        Int      @id @default(autoincrement())
+  threadId  String   @unique
+  state     String   @default("FORMING")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  metadata  Json?
+
+  members RaidMember[]
+}
+
+model RaidMember {
+  id          Int      @id @default(autoincrement())
+  raidId      Int
+  userId      String
+  role        String
+  joinedAt    DateTime @default(now())
+  contribution Int     @default(0)
+  metadata    Json?
+
+  raid Raid @relation(fields: [raidId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([raidId, userId])
 }

--- a/src/commands/core/profile.ts
+++ b/src/commands/core/profile.ts
@@ -5,6 +5,7 @@ import {
 } from 'discord.js';
 import { prisma } from '../../lib/db.js';
 import { extractBuffState } from '../../services/buffs.js';
+import { buildAttributeSummary, xpToNext } from '../../services/progression.js';
 
 function progressBar(fraction: number, size = 12) {
   const full = '█';
@@ -15,10 +16,6 @@ function progressBar(fraction: number, size = 12) {
 
 function formatV(n: number) {
   return n.toLocaleString('es-ES');
-}
-
-function xpToNext(level: number) {
-  return Math.max(50, level * level * 100);
 }
 
 function msToHMS(ms: number) {
@@ -105,6 +102,11 @@ export default {
           name: '🎯 Progreso',
           value: `**Nivel:** ${u.level}\n**XP:** ${formatV(u.xp)} / ${formatV(xpTarget)}\n\`${xpBar}\``,
           inline: true,
+        },
+        {
+          name: '🛠️ Atributos',
+          value: buildAttributeSummary(u),
+          inline: false,
         },
         {
           name: '📦 Inventario',

--- a/src/commands/rpg/adventure.ts
+++ b/src/commands/rpg/adventure.ts
@@ -1,0 +1,194 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+  ActionRowBuilder,
+} from 'discord.js';
+import { prisma } from '../../lib/db.js';
+import { buildPlayerCombatant, buildMonsterCombatant } from '../../services/combat.js';
+import { grantExperience } from '../../services/progression.js';
+
+interface AdventureSession {
+  id: string;
+  userId: string;
+  optionMap: Record<string, DecisionOption>;
+  resolved: boolean;
+}
+
+interface DecisionOption {
+  label: string;
+  successChance: number;
+  success: () => Promise<string>;
+  failure: () => Promise<string>;
+}
+
+const adventureSessions = new Map<string, AdventureSession>();
+
+function randomId() {
+  return `${Date.now()}-${Math.floor(Math.random() * 9999)}`;
+}
+
+async function handleLoot(userId: string) {
+  const coins = 40 + Math.floor(Math.random() * 80);
+  const xp = 20 + Math.floor(Math.random() * 30);
+  await prisma.user.update({ where: { id: userId }, data: { vcoins: { increment: coins } } });
+  await grantExperience(userId, xp);
+  return `Encontraste un alijo de suministros. +${coins} V Coins · +${xp} XP`;
+}
+
+async function handleCombat(userId: string) {
+  const player = await buildPlayerCombatant(userId);
+  const monster = await buildMonsterCombatant();
+  if (!player || !monster) {
+    return 'No había enemigos que enfrentar.';
+  }
+
+  const playerScore = player.attack + player.defense + player.intellect + Math.random() * (player.luck + 10);
+  const enemyScore = monster.state.attack + monster.state.defense + monster.state.intellect + Math.random() * (monster.state.luck + 10);
+  if (playerScore >= enemyScore) {
+    const coins = Math.max(20, Math.round(monster.vcoinsMin + Math.random() * (monster.vcoinsMax - monster.vcoinsMin + 1)));
+    const xp = Math.max(15, monster.xpReward);
+    await prisma.user.update({
+      where: { id: userId },
+      data: { vcoins: { increment: coins }, health: Math.max(1, Math.min(player.hpMax, player.hp)) },
+    });
+    await grantExperience(userId, xp);
+    return `Derrotaste a ${monster.name} en una escaramuza rápida. +${coins} V Coins · +${xp} XP`;
+  }
+
+  const damage = Math.round(Math.random() * 20) + 10;
+  const currentHp = Math.max(1, player.hp);
+  const decrement = Math.min(damage, Math.max(0, currentHp - 1));
+  await prisma.user.update({
+    where: { id: userId },
+    data: {
+      health: { decrement },
+    },
+  });
+  return `El enemigo te superó. Pierdes ${damage} de salud.`;
+}
+
+async function buildDecision(userId: string) {
+  const sessionId = randomId();
+  const healAmount = 20 + Math.floor(Math.random() * 20);
+  const optionMap: Record<string, DecisionOption> = {
+    explore: {
+      label: 'Explorar la caverna',
+      successChance: 0.6,
+      success: async () => {
+        const coins = 60 + Math.floor(Math.random() * 60);
+        await prisma.user.update({ where: { id: userId }, data: { vcoins: { increment: coins } } });
+        await grantExperience(userId, 35);
+        return `Descubres una cámara brillante. +${coins} V Coins · +35 XP`;
+      },
+      failure: async () => {
+        const dmg = 25 + Math.floor(Math.random() * 10);
+        const current = await prisma.user.findUnique({ where: { id: userId }, select: { health: true } });
+        if (current) {
+          const nextHealth = Math.max(1, current.health - dmg);
+          await prisma.user.update({ where: { id: userId }, data: { health: nextHealth } });
+        }
+        return `Una trampa se activa. Pierdes ${dmg} de salud.`;
+      },
+    },
+    rest: {
+      label: 'Acampar y descansar',
+      successChance: 0.8,
+      success: async () => {
+        const current = await prisma.user.findUnique({ where: { id: userId }, select: { health: true, healthMax: true } });
+        if (current) {
+          const next = Math.min(current.healthMax, current.health + healAmount);
+          await prisma.user.update({ where: { id: userId }, data: { health: next } });
+        }
+        return `Recuperas energías y sanas ${healAmount} de salud.`;
+      },
+      failure: async () => {
+        const coinsLost = 30;
+        const current = await prisma.user.findUnique({ where: { id: userId }, select: { vcoins: true } });
+        if (current) {
+          const next = Math.max(0, current.vcoins - coinsLost);
+          await prisma.user.update({ where: { id: userId }, data: { vcoins: next } });
+        }
+        return `Mientras duermes te roban ${coinsLost} V Coins.`;
+      },
+    },
+  };
+  const session: AdventureSession = { id: sessionId, userId, optionMap, resolved: false };
+  adventureSessions.set(sessionId, session);
+  return session;
+}
+
+export default {
+  data: new SlashCommandBuilder().setName('adventure').setDescription('Vive un evento aleatorio de aventura.'),
+  ns: 'adventure',
+  async execute(interaction: ChatInputCommandInteraction) {
+    const uid = interaction.user.id;
+    const user = await prisma.user.findUnique({ where: { id: uid } });
+    if (!user) {
+      return interaction.reply({ content: 'Primero usa `/start` para comenzar la aventura.', ephemeral: true });
+    }
+
+    const roll = Math.random();
+    if (roll < 0.33) {
+      const text = await handleLoot(uid);
+      const embed = new EmbedBuilder().setTitle('Evento: Botín inesperado').setDescription(text).setColor(0xf1c40f);
+      return interaction.reply({ embeds: [embed] });
+    }
+    if (roll < 0.66) {
+      const text = await handleCombat(uid);
+      const embed = new EmbedBuilder().setTitle('Encuentro de Combate').setDescription(text).setColor(0xe74c3c);
+      return interaction.reply({ embeds: [embed] });
+    }
+
+    const session = await buildDecision(uid);
+    const embed = new EmbedBuilder()
+      .setTitle('Cruce de caminos')
+      .setDescription('Una bifurcación aparece en el camino. ¿Qué decides?')
+      .setColor(0x9b59b6);
+    const row = new ActionRowBuilder<ButtonBuilder>();
+    for (const [key, option] of Object.entries(session.optionMap)) {
+      row.addComponents(
+        new ButtonBuilder()
+          .setCustomId(`adventure:choice:${session.id}:${key}`)
+          .setLabel(option.label)
+          .setStyle(ButtonStyle.Secondary),
+      );
+    }
+    return interaction.reply({ embeds: [embed], components: [row] });
+  },
+  async handleInteraction(interaction: ButtonInteraction) {
+    if (!interaction.isButton()) return;
+    const [ns, action, sessionId, optionId] = interaction.customId.split(':');
+    if (ns !== 'adventure' || action !== 'choice' || !sessionId || !optionId) return;
+
+    const session = adventureSessions.get(sessionId);
+    if (!session || session.resolved) {
+      return interaction.reply({ content: 'Esta decisión ya fue tomada.', ephemeral: true });
+    }
+
+    if (interaction.user.id !== session.userId) {
+      return interaction.reply({ content: 'Solo el aventurero original puede decidir.', ephemeral: true });
+    }
+
+    const option = session.optionMap[optionId];
+    if (!option) {
+      return interaction.reply({ content: 'Opción no válida.', ephemeral: true });
+    }
+
+    session.resolved = true;
+    adventureSessions.delete(sessionId);
+
+    const success = Math.random() < option.successChance;
+    const result = success ? await option.success() : await option.failure();
+
+    const embed = new EmbedBuilder()
+      .setTitle('Resolución de la aventura')
+      .setDescription(result)
+      .setColor(success ? 0x2ecc71 : 0xe67e22);
+
+    await interaction.update({ embeds: [embed], components: [] });
+  },
+};

--- a/src/commands/rpg/battle.ts
+++ b/src/commands/rpg/battle.ts
@@ -1,0 +1,235 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ActionRowBuilder,
+  ButtonInteraction,
+} from 'discord.js';
+import { prisma } from '../../lib/db.js';
+import {
+  buildMonsterCombatant,
+  buildPlayerCombatant,
+  createBattleState,
+  describeBattle,
+  enemyTurn,
+  runPlayerSkill,
+  SKILL_DEFS,
+  battleStore,
+  cleanupBattle,
+} from '../../services/combat.js';
+import { grantExperience } from '../../services/progression.js';
+
+const DAILY_LIMIT = 5;
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getDailyKey() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function incrementBattleCounter(metadata: any) {
+  const root = isRecord(metadata) ? { ...metadata } : {};
+  const key = getDailyKey();
+  const battleMeta = isRecord(root.battle) ? { ...root.battle } : {};
+  const daily = isRecord(battleMeta.daily) ? { ...battleMeta.daily } : {};
+  const entry = isRecord(daily[key]) ? { ...daily[key] } : { count: 0 };
+  entry.count = (entry.count ?? 0) + 1;
+  daily[key] = entry;
+  battleMeta.daily = daily;
+  root.battle = battleMeta;
+  return root;
+}
+
+function getBattleCount(metadata: any) {
+  const root = isRecord(metadata) ? metadata : {};
+  const daily = isRecord(root.battle) && isRecord(root.battle.daily) ? root.battle.daily : {};
+  const key = getDailyKey();
+  const entry = isRecord(daily[key]) ? daily[key] : null;
+  const count = entry?.count ?? 0;
+  return count;
+}
+
+function buildBattleEmbed(state: ReturnType<typeof describeBattle> & { enemyName: string }) {
+  return new EmbedBuilder()
+    .setTitle(state.title)
+    .addFields(
+      { name: 'Jugador', value: state.playerLine, inline: true },
+      { name: state.enemyName, value: state.enemyLine, inline: true },
+      { name: 'Acciones', value: state.log || '—', inline: false },
+    )
+    .setColor(state.log.includes('🎉') ? 0x2ecc71 : 0x3498db);
+}
+
+function buildComponents(battleId: string, state: { active: boolean; cooldowns: Record<string, number> }) {
+  if (!state.active) return [];
+  const row = new ActionRowBuilder<ButtonBuilder>();
+  for (const skill of SKILL_DEFS) {
+    const btn = new ButtonBuilder()
+      .setCustomId(`battle:skill:${battleId}:${skill.id}`)
+      .setLabel(skill.name)
+      .setStyle(ButtonStyle.Primary)
+      .setDisabled((state.cooldowns[skill.id] ?? 0) > 0);
+    row.addComponents(btn);
+  }
+  const escape = new ButtonBuilder()
+    .setCustomId(`battle:run:${battleId}`)
+    .setLabel('Huir')
+    .setStyle(ButtonStyle.Danger);
+  row.addComponents(escape);
+  return [row];
+}
+
+async function grantBattleLoot(userId: string, luck: number) {
+  const roll = Math.random();
+  const luckBonus = Math.min(0.4, luck * 0.02);
+  if (roll > 0.2 + luckBonus) return null;
+
+  const candidates = await prisma.item.findMany({ where: { type: 'MATERIAL' }, take: 50 });
+  if (!candidates.length) return null;
+  const item = candidates[Math.floor(Math.random() * candidates.length)];
+  await prisma.userItem.upsert({
+    where: { userId_itemId: { userId, itemId: item.id } },
+    create: { userId, itemId: item.id, quantity: 1 },
+    update: { quantity: { increment: 1 } },
+  });
+  return item.name;
+}
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('battle')
+    .setDescription('Inicia un combate rápido por turnos contra un enemigo.'),
+  ns: 'battle',
+  async execute(interaction: ChatInputCommandInteraction) {
+    const uid = interaction.user.id;
+    const user = await prisma.user.findUnique({ where: { id: uid } });
+    if (!user) {
+      return interaction.reply({ content: 'Primero usa `/start` para crear tu perfil.', ephemeral: true });
+    }
+
+    if (battleStore.some((state) => state.userId === uid && state.active)) {
+      return interaction.reply({ content: 'Ya tienes una batalla en curso.', ephemeral: true });
+    }
+
+    const count = getBattleCount(user.metadata);
+    if (count >= DAILY_LIMIT) {
+      return interaction.reply({ content: `Has alcanzado el límite de ${DAILY_LIMIT} batallas hoy.`, ephemeral: true });
+    }
+
+    const player = await buildPlayerCombatant(uid);
+    const monster = await buildMonsterCombatant();
+    if (!player || !monster) {
+      return interaction.reply({ content: 'No hay enemigos disponibles por ahora.', ephemeral: true });
+    }
+
+    const updatedMeta = incrementBattleCounter(user.metadata);
+    await prisma.user.update({ where: { id: uid }, data: { metadata: updatedMeta } });
+
+    const state = createBattleState({
+      userId: uid,
+      player,
+      enemy: monster.state,
+      enemyId: monster.monsterId,
+      rewards: { xp: monster.xpReward, vcoinsMin: monster.vcoinsMin, vcoinsMax: monster.vcoinsMax, name: monster.name },
+    });
+
+    const desc = describeBattle(state);
+    const embed = buildBattleEmbed({ ...desc, enemyName: monster.name });
+    const components = buildComponents(state.id, { active: state.active, cooldowns: state.player.cooldowns });
+
+    const reply = await interaction.reply({ embeds: [embed], components, fetchReply: true });
+    state.messageId = reply.id;
+    state.channelId = reply.channelId;
+  },
+  async handleInteraction(interaction: ButtonInteraction) {
+    if (!interaction.isButton()) return;
+    const [ns, action, battleId, skillId] = interaction.customId.split(':');
+    if (ns !== 'battle') return;
+
+    const state = battleStore.get(battleId);
+    if (!state) {
+      if (interaction.replied || interaction.deferred) return;
+      return interaction.reply({ content: 'La batalla ya terminó.', ephemeral: true });
+    }
+
+    if (interaction.user.id !== state.userId) {
+      return interaction.reply({ content: 'Solo el jugador que inició la batalla puede usar estos botones.', ephemeral: true });
+    }
+
+    if (action === 'run') {
+      state.active = false;
+      state.log.push('🏳️ Te retiras de la batalla.');
+      cleanupBattle(state.id);
+      const desc = describeBattle(state);
+      const embed = buildBattleEmbed({ ...desc, enemyName: state.enemy.name });
+      return interaction.update({ embeds: [embed], components: [] });
+    }
+
+    if (action !== 'skill' || !skillId) return;
+
+    try {
+      runPlayerSkill(state, skillId);
+    } catch (err: any) {
+      return interaction.reply({ content: err.message ?? 'No puedes usar esa habilidad.', ephemeral: true });
+    }
+
+    let finished = false;
+    if (!state.active) {
+      finished = true;
+    } else {
+      const enemyAction = enemyTurn(state);
+      if (!enemyAction) {
+        finished = true;
+      }
+      if (!state.active) {
+        finished = true;
+      }
+    }
+
+    const rewards: string[] = [];
+    if (!state.active && state.enemy.hp <= 0) {
+      const xpGain = Math.max(5, state.rewards.xp);
+      const minCoins = state.rewards.vcoins.min ?? 5;
+      const maxCoins = Math.max(minCoins, state.rewards.vcoins.max ?? minCoins + 10);
+      const coins = Math.floor(Math.random() * (maxCoins - minCoins + 1)) + minCoins;
+      const luck = state.player.luck ?? 0;
+      const critBonus = Math.random() < Math.min(0.5, luck * 0.02) ? Math.round(coins * 0.4) : 0;
+      const totalCoins = coins + critBonus;
+      await prisma.user.update({
+        where: { id: state.userId },
+        data: { vcoins: { increment: totalCoins }, health: Math.max(1, Math.min(state.player.hpMax, state.player.hp)) },
+      });
+      await grantExperience(state.userId, xpGain);
+      rewards.push(`+${xpGain} XP`, `+${totalCoins} V Coins`);
+      if (critBonus > 0) {
+        rewards.push('💫 ¡Suerte crítica!');
+      }
+      const loot = await grantBattleLoot(state.userId, luck);
+      if (loot) {
+        rewards.push(`🎁 Botín: ${loot}`);
+      }
+      state.log.push(`🏆 Recompensas: ${rewards.join(' · ')}`);
+      cleanupBattle(state.id);
+    } else if (!state.active && state.player.hp <= 0) {
+      await prisma.user.update({
+        where: { id: state.userId },
+        data: {
+          health: Math.round(state.player.hpMax * 0.25),
+          deaths: { increment: 1 },
+        },
+      });
+      state.log.push('🩹 Tu salud ha sido restaurada parcialmente.');
+      cleanupBattle(state.id);
+    }
+
+    const desc = describeBattle(state);
+    const embed = buildBattleEmbed({ ...desc, enemyName: state.enemy.name });
+    const components = finished ? [] : buildComponents(state.id, { active: state.active, cooldowns: state.player.cooldowns });
+
+    await interaction.update({ embeds: [embed], components });
+  },
+};

--- a/src/commands/rpg/boss.ts
+++ b/src/commands/rpg/boss.ts
@@ -1,0 +1,78 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+} from 'discord.js';
+import { prisma } from '../../lib/db.js';
+import { attackBoss, getBossWithDamage } from '../../services/boss.js';
+import { useScopedCooldown } from '../../services/cooldowns.js';
+
+const ATTACK_COOLDOWN = 30 * 60 * 1000; // 30 minutos
+
+function formatProgress(current: number, max: number) {
+  const pct = Math.max(0, Math.min(1, current / max));
+  const filled = Math.round(pct * 20);
+  return `HP: ${current.toLocaleString('es-ES')} / ${max.toLocaleString('es-ES')}\n[${'█'.repeat(filled)}${'░'.repeat(20 - filled)}] ${(pct * 100).toFixed(1)}%`;
+}
+
+function buildLeaderboard(rows: { userId: string; damage: number }[]) {
+  if (!rows.length) return 'Nadie ha participado todavía.';
+  return rows
+    .map((row, idx) => {
+      const tag = `<@${row.userId}>`;
+      return `**${idx + 1}.** ${tag} — ${row.damage.toLocaleString('es-ES')} daño`;
+    })
+    .join('\n');
+}
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('boss')
+    .setDescription('Consulta o ataca al jefe semanal.')
+    .addSubcommand((sub) => sub.setName('status').setDescription('Muestra el progreso del jefe actual.'))
+    .addSubcommand((sub) => sub.setName('attack').setDescription('Ataca al jefe semanal.')),
+  ns: 'boss',
+  async execute(interaction: ChatInputCommandInteraction) {
+    const uid = interaction.user.id;
+    const sub = interaction.options.getSubcommand();
+    const user = await prisma.user.findUnique({ where: { id: uid } });
+    if (!user) {
+      return interaction.reply({ content: 'Primero usa `/start` para participar.', ephemeral: true });
+    }
+
+    if (sub === 'status') {
+      const { boss, damages } = await getBossWithDamage();
+      const embed = new EmbedBuilder()
+        .setTitle(`Jefe semanal: ${boss.name}`)
+        .setDescription(formatProgress(boss.hp, boss.maxHp))
+        .addFields({ name: 'Top 10 daño', value: buildLeaderboard(damages) })
+        .setColor(0xc0392b);
+      return interaction.reply({ embeds: [embed] });
+    }
+
+    const cooldown = useScopedCooldown('boss-attack', uid, ATTACK_COOLDOWN);
+    if (!cooldown.ok) {
+      const minutes = Math.ceil(cooldown.remaining / 60000);
+      return interaction.reply({ content: `Debes esperar ${minutes} minuto(s) antes de atacar de nuevo.`, ephemeral: true });
+    }
+
+    const result = await attackBoss(uid);
+    const embed = new EmbedBuilder()
+      .setTitle(`Ataque al jefe: ${result.boss.name}`)
+      .setDescription(`Infliges ${result.damage.toLocaleString('es-ES')} daño${result.crit ? ' crítico' : ''}.\n${formatProgress(result.boss.hp, result.boss.maxHp)}`)
+      .setColor(result.defeated ? 0x27ae60 : 0xe74c3c);
+
+    if (result.defeated) {
+      embed.addFields({ name: 'Estado', value: '🎉 ¡El jefe ha sido derrotado! Obtendrás recompensas al finalizar la semana.' });
+    }
+
+    const damages = await prisma.bossDamage.findMany({
+      where: { bossId: result.boss.id },
+      orderBy: { damage: 'desc' },
+      take: 10,
+    });
+    embed.addFields({ name: 'Top 10 daño', value: buildLeaderboard(damages) });
+
+    await interaction.reply({ embeds: [embed] });
+  },
+};

--- a/src/commands/rpg/raid.ts
+++ b/src/commands/rpg/raid.ts
@@ -1,0 +1,553 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  ButtonBuilder,
+  ButtonStyle,
+  ActionRowBuilder,
+  ButtonInteraction,
+  EmbedBuilder,
+  ThreadChannel,
+  TextChannel,
+} from 'discord.js';
+import { prisma } from '../../lib/db.js';
+import { grantExperience } from '../../services/progression.js';
+
+const RAID_MIN = 3;
+const RAID_MAX = 5;
+const REVIVE_COOLDOWN = 5 * 60 * 1000; // 5 minutos
+
+const ROLE_LABELS: Record<RaidRole, string> = {
+  damage: '💥 Daño',
+  support: '✨ Soporte',
+  tank: '🛡️ Tanque',
+};
+
+const RAID_PHASES: RaidPhase[] = [
+  {
+    name: 'Anillos Centinela',
+    description: 'Interrumpe con precisión y mantén al grupo protegido.',
+    threshold: 3,
+    enrageLimit: 3,
+    mechanics: [
+      { mechanic: 'interrupt', text: 'El Centinela canaliza un pulso. ¡Necesita interrupción inmediata!' },
+      { mechanic: 'shield', text: 'Una onda expansiva se acerca, prepara escudos.' },
+      { mechanic: 'taunt', text: 'El jefe fija a un aliado. El tanque debe atraer la atención.' },
+    ],
+  },
+  {
+    name: 'Corazón Ígneo',
+    description: 'Coordina burst y defensas para evitar el enrage.',
+    threshold: 4,
+    enrageLimit: 4,
+    mechanics: [
+      { mechanic: 'burst', text: 'Cristales inestables aparecen. Los daños deben detonarlos.' },
+      { mechanic: 'shield', text: 'Tormenta ígnea: los soportes levantan barreras.' },
+      { mechanic: 'interrupt', text: 'El núcleo intenta regenerarse. ¡Interrúmpelo!' },
+    ],
+  },
+];
+
+const MECHANIC_ROLE: Record<RaidMechanic, RaidRole> = {
+  interrupt: 'damage',
+  shield: 'support',
+  taunt: 'tank',
+  burst: 'damage',
+};
+
+const MECHANIC_REWARD: Record<RaidMechanic, number> = {
+  interrupt: 2,
+  shield: 1,
+  taunt: 1,
+  burst: 2,
+};
+
+type RaidRole = 'damage' | 'support' | 'tank';
+type RaidMechanic = 'interrupt' | 'shield' | 'taunt' | 'burst';
+
+interface RaidPhase {
+  name: string;
+  description: string;
+  threshold: number;
+  enrageLimit: number;
+  mechanics: { mechanic: RaidMechanic; text: string }[];
+}
+
+interface RaidMemberState {
+  userId: string;
+  role: RaidRole;
+  down: boolean;
+  reviveAvailableAt: number;
+  contribution: number;
+}
+
+interface RaidSession {
+  id: string;
+  raidId: number;
+  leaderId: string;
+  threadId: string;
+  state: 'FORMING' | 'ACTIVE' | 'COMPLETE' | 'FAILED' | 'CANCELLED';
+  members: Map<string, RaidMemberState>;
+  phaseIndex: number;
+  progress: number;
+  enrageCounter: number;
+  lobbyMessageId?: string;
+  promptMessageId?: string;
+  prompt?: RaidPrompt;
+  thread?: ThreadChannel;
+}
+
+interface RaidPrompt {
+  id: string;
+  mechanic: RaidMechanic;
+  text: string;
+  expiresAt: number;
+  timeout: NodeJS.Timeout;
+  responders: Set<string>;
+}
+
+const raidSessions = new Map<string, RaidSession>();
+
+function randomId() {
+  return `${Date.now()}-${Math.floor(Math.random() * 9999)}`;
+}
+
+function getSessionByUser(userId: string) {
+  for (const session of raidSessions.values()) {
+    if (session.members.has(userId)) return session;
+  }
+  return null;
+}
+
+function buildLobbyEmbed(session: RaidSession) {
+  const phase = RAID_PHASES[session.phaseIndex];
+  const lines = Array.from(session.members.values()).map((member) => {
+    const status = member.down ? ' (caído)' : '';
+    return `${ROLE_LABELS[member.role]} — <@${member.userId}>${status}`;
+  });
+  const content = lines.length ? lines.join('\n') : 'Nadie se ha unido todavía.';
+  return new EmbedBuilder()
+    .setTitle('Formación de raid')
+    .setDescription(`Fase actual: **${phase.name}** — ${phase.description}`)
+    .addFields({ name: `Miembros (${session.members.size}/${RAID_MAX})`, value: content })
+    .setColor(0x2980b9);
+}
+
+function buildLobbyComponents(session: RaidSession) {
+  const rowRoles = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder().setCustomId(`raid:join:${session.id}:damage`).setLabel('Daño').setStyle(ButtonStyle.Primary),
+    new ButtonBuilder().setCustomId(`raid:join:${session.id}:support`).setLabel('Soporte').setStyle(ButtonStyle.Success),
+    new ButtonBuilder().setCustomId(`raid:join:${session.id}:tank`).setLabel('Tanque').setStyle(ButtonStyle.Secondary),
+  );
+  const hasMinimum = session.members.size >= RAID_MIN && hasRole(session, 'tank') && hasRole(session, 'support') && hasRole(session, 'damage');
+  const rowControls = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`raid:start:${session.id}`)
+      .setLabel('Iniciar')
+      .setStyle(ButtonStyle.Success)
+      .setDisabled(!hasMinimum),
+    new ButtonBuilder().setCustomId(`raid:leave:${session.id}`).setLabel('Salir').setStyle(ButtonStyle.Danger),
+    new ButtonBuilder().setCustomId(`raid:cancel:${session.id}`).setLabel('Cancelar').setStyle(ButtonStyle.Secondary),
+  );
+  return [rowRoles, rowControls];
+}
+
+function buildPromptComponents(session: RaidSession) {
+  const rows = [
+    new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder().setCustomId(`raid:act:${session.id}:damage`).setLabel('Daño').setStyle(ButtonStyle.Primary),
+      new ButtonBuilder().setCustomId(`raid:act:${session.id}:support`).setLabel('Soporte').setStyle(ButtonStyle.Success),
+      new ButtonBuilder().setCustomId(`raid:act:${session.id}:tank`).setLabel('Tanque').setStyle(ButtonStyle.Secondary),
+    ),
+  ];
+  if (hasRole(session, 'support')) {
+    rows.push(
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(`raid:revive:${session.id}`)
+          .setLabel('Revivir aliados')
+          .setStyle(ButtonStyle.Secondary),
+      ),
+    );
+  }
+  return rows;
+}
+
+function hasRole(session: RaidSession, role: RaidRole) {
+  return Array.from(session.members.values()).some((member) => member.role === role);
+}
+
+function pickMechanic(session: RaidSession) {
+  const phase = RAID_PHASES[session.phaseIndex];
+  const pick = phase.mechanics[Math.floor(Math.random() * phase.mechanics.length)];
+  return pick;
+}
+
+async function ensureThread(session: RaidSession, interaction?: ChatInputCommandInteraction | ButtonInteraction) {
+  if (session.thread) return session.thread;
+  if (!interaction) return null;
+  const channel = await interaction.client.channels.fetch(session.threadId);
+  if (!channel || !(channel instanceof ThreadChannel)) {
+    throw new Error('No se pudo recuperar el hilo de la raid.');
+  }
+  session.thread = channel;
+  return channel;
+}
+
+async function sendNextPrompt(session: RaidSession, interaction?: ButtonInteraction) {
+  const thread = session.thread ?? (await ensureThread(session, interaction));
+  if (!thread) return;
+
+  const phase = RAID_PHASES[session.phaseIndex];
+  const selection = pickMechanic(session);
+  const promptId = randomId();
+  const timeout = setTimeout(() => handlePromptTimeout(session.id, promptId), 30_000);
+  const prompt: RaidPrompt = {
+    id: promptId,
+    mechanic: selection.mechanic,
+    text: selection.text,
+    expiresAt: Date.now() + 30_000,
+    timeout,
+    responders: new Set(),
+  };
+  session.prompt = prompt;
+
+  const embed = new EmbedBuilder()
+    .setTitle(`Fase ${session.phaseIndex + 1}: ${phase.name}`)
+    .setDescription(selection.text)
+    .setFooter({ text: `Mecánica requerida: ${ROLE_LABELS[MECHANIC_ROLE[selection.mechanic]]}` })
+    .setColor(0xd35400);
+
+  const message = await thread.send({ embeds: [embed], components: buildPromptComponents(session) });
+  session.promptMessageId = message.id;
+}
+
+function handlePromptTimeout(sessionId: string, promptId: string) {
+  const session = raidSessions.get(sessionId);
+  if (!session || session.state !== 'ACTIVE' || !session.prompt || session.prompt.id !== promptId) return;
+  resolvePrompt(session, false, null, 'Tiempo agotado. La mecánica falla.');
+}
+
+async function resolvePrompt(session: RaidSession, success: boolean, actor: RaidMemberState | null, reason: string) {
+  if (!session.prompt) return;
+  const mechanic = session.prompt.mechanic;
+  clearTimeout(session.prompt.timeout);
+  const promptMessageId = session.promptMessageId;
+  session.prompt = undefined;
+  session.promptMessageId = undefined;
+
+  const thread = session.thread;
+  if (promptMessageId && thread) {
+    try {
+      const message = await thread.messages.fetch(promptMessageId);
+      await message.edit({ components: [] });
+    } catch (err) {
+      // ignore
+    }
+  }
+
+  const phase = RAID_PHASES[session.phaseIndex];
+  if (success && actor) {
+    actor.contribution += MECHANIC_REWARD[mechanic] ?? 1;
+    session.progress += 1;
+    session.enrageCounter = Math.max(0, session.enrageCounter - 1);
+    if (thread) {
+      await thread.send(`✅ ${ROLE_LABELS[actor.role]} <@${actor.userId}> resuelve la mecánica. ${reason}`);
+    }
+    if (session.progress >= phase.threshold) {
+      session.phaseIndex += 1;
+      session.progress = 0;
+      session.enrageCounter = 0;
+      if (thread) {
+        await thread.send(`🎉 Fase completada. ${session.phaseIndex < RAID_PHASES.length ? 'Prepárense para la siguiente.' : '¡Raid completada!'} `);
+      }
+      if (session.phaseIndex >= RAID_PHASES.length) {
+        await finishRaid(session, true);
+        return;
+      }
+    }
+    setTimeout(() => {
+      if (session.state === 'ACTIVE') {
+        sendNextPrompt(session);
+      }
+    }, 4000);
+  } else {
+    session.enrageCounter += 1;
+    if (thread) {
+      await thread.send(`❌ La mecánica falla. ${reason}`);
+    }
+    const alive = Array.from(session.members.values()).filter((m) => !m.down);
+    if (alive.length) {
+      const victim = alive[Math.floor(Math.random() * alive.length)];
+      victim.down = true;
+      if (thread) {
+        await thread.send(`💀 <@${victim.userId}> cae incapacitado.`);
+      }
+    }
+    if (session.enrageCounter >= phase.enrageLimit) {
+      if (thread) {
+        await thread.send('🔥 El jefe entra en ENRAGE. La raid fracasa.');
+      }
+      await finishRaid(session, false);
+      return;
+    }
+    setTimeout(() => {
+      if (session.state === 'ACTIVE') {
+        sendNextPrompt(session);
+      }
+    }, 4000);
+  }
+}
+
+async function finishRaid(session: RaidSession, success: boolean) {
+  session.state = success ? 'COMPLETE' : 'FAILED';
+  if (session.prompt) {
+    clearTimeout(session.prompt.timeout);
+    session.prompt = undefined;
+  }
+  const rewards = success ? { xp: 180, vcoins: 220 } : { xp: 60, vcoins: 60 };
+  const members = Array.from(session.members.values());
+  await prisma.raid.update({
+    where: { id: session.raidId },
+    data: {
+      state: success ? 'COMPLETED' : 'FAILED',
+      metadata: { success, finishedAt: new Date().toISOString() },
+    },
+  });
+  for (const member of members) {
+    await prisma.raidMember.upsert({
+      where: { raidId_userId: { raidId: session.raidId, userId: member.userId } },
+      create: { raidId: session.raidId, userId: member.userId, role: member.role, contribution: member.contribution },
+      update: { contribution: member.contribution, role: member.role },
+    });
+    await prisma.user.update({
+      where: { id: member.userId },
+      data: {
+        vcoins: { increment: success ? rewards.vcoins : Math.round(rewards.vcoins / 2) },
+      },
+    });
+    await grantExperience(member.userId, success ? rewards.xp : Math.round(rewards.xp / 2));
+  }
+  if (session.thread) {
+    await session.thread.send(success ? '🏆 ¡Raid completada! Recompensas distribuidas.' : '☠️ La raid ha fracasado. Inténtenlo de nuevo.');
+  }
+  raidSessions.delete(session.id);
+}
+
+async function updateLobbyMessage(session: RaidSession, interaction: ButtonInteraction) {
+  if (!session.lobbyMessageId) return;
+  const thread = session.thread ?? (await ensureThread(session, interaction));
+  if (!thread) return;
+  const message = await thread.messages.fetch(session.lobbyMessageId);
+  await interaction.update({ embeds: [buildLobbyEmbed(session)], components: buildLobbyComponents(session) });
+  if (message.id !== interaction.message.id) {
+    await message.edit({ embeds: [buildLobbyEmbed(session)], components: buildLobbyComponents(session) });
+  }
+}
+
+async function createRaid(interaction: ChatInputCommandInteraction, userId: string) {
+  const channel = interaction.channel;
+  if (!channel || !(channel instanceof TextChannel)) {
+    await interaction.reply({ content: 'Este comando solo funciona en canales de texto dentro del servidor.', ephemeral: true });
+    return;
+  }
+  const baseName = `raid-${interaction.user.username}`.slice(0, 20);
+  const thread = await channel.threads.create({
+    name: baseName,
+    autoArchiveDuration: 60,
+    reason: 'Raid cooperativa',
+  });
+  const raidRecord = await prisma.raid.create({
+    data: {
+      threadId: thread.id,
+      state: 'FORMING',
+      metadata: { leaderId: userId },
+    },
+  });
+  const session: RaidSession = {
+    id: String(raidRecord.id),
+    raidId: raidRecord.id,
+    leaderId: userId,
+    threadId: thread.id,
+    state: 'FORMING',
+    members: new Map(),
+    phaseIndex: 0,
+    progress: 0,
+    enrageCounter: 0,
+    thread,
+  };
+  raidSessions.set(session.id, session);
+  const lobbyMessage = await thread.send({ embeds: [buildLobbyEmbed(session)], components: buildLobbyComponents(session) });
+  session.lobbyMessageId = lobbyMessage.id;
+  await interaction.reply({ content: `Raid creada en ${thread.toString()}. Únete desde el hilo.`, ephemeral: true });
+}
+
+async function handleJoin(session: RaidSession, interaction: ButtonInteraction, role: RaidRole) {
+  if (session.state !== 'FORMING') {
+    return interaction.reply({ content: 'La raid ya comenzó.', ephemeral: true });
+  }
+  if (session.members.size >= RAID_MAX && !session.members.has(interaction.user.id)) {
+    return interaction.reply({ content: 'La raid ya está completa.', ephemeral: true });
+  }
+  const existing = session.members.get(interaction.user.id);
+  const member: RaidMemberState = existing ?? {
+    userId: interaction.user.id,
+    role,
+    down: false,
+    reviveAvailableAt: 0,
+    contribution: 0,
+  };
+  member.role = role;
+  session.members.set(interaction.user.id, member);
+  await prisma.raidMember.upsert({
+    where: { raidId_userId: { raidId: session.raidId, userId: interaction.user.id } },
+    create: { raidId: session.raidId, userId: interaction.user.id, role },
+    update: { role },
+  });
+  await updateLobbyMessage(session, interaction);
+  await interaction.followUp({ content: `Te uniste como ${ROLE_LABELS[role]}.`, ephemeral: true });
+}
+
+async function handleLeave(session: RaidSession, interaction: ButtonInteraction) {
+  if (session.state !== 'FORMING') {
+    return interaction.reply({ content: 'No puedes salir mientras la raid está en progreso.', ephemeral: true });
+  }
+  if (!session.members.has(interaction.user.id)) {
+    return interaction.reply({ content: 'No estás en esta raid.', ephemeral: true });
+  }
+  session.members.delete(interaction.user.id);
+  await prisma.raidMember.deleteMany({ where: { raidId: session.raidId, userId: interaction.user.id } });
+  await updateLobbyMessage(session, interaction);
+  await interaction.followUp({ content: 'Saliste de la raid.', ephemeral: true });
+}
+
+async function handleCancel(session: RaidSession, interaction: ButtonInteraction) {
+  if (interaction.user.id !== session.leaderId) {
+    return interaction.reply({ content: 'Solo el líder puede cancelar la raid.', ephemeral: true });
+  }
+  session.state = 'CANCELLED';
+  raidSessions.delete(session.id);
+  await prisma.raid.update({ where: { id: session.raidId }, data: { state: 'CANCELLED' } });
+  if (session.thread) {
+    await session.thread.send('La raid fue cancelada por el líder.');
+  }
+  await interaction.update({ components: [], embeds: [buildLobbyEmbed(session)] });
+}
+
+async function handleStart(session: RaidSession, interaction: ButtonInteraction) {
+  if (interaction.user.id !== session.leaderId) {
+    return interaction.reply({ content: 'Solo el líder puede iniciar la raid.', ephemeral: true });
+  }
+  if (session.members.size < RAID_MIN || !hasRole(session, 'tank') || !hasRole(session, 'support') || !hasRole(session, 'damage')) {
+    return interaction.reply({ content: 'Necesitas al menos 3 jugadores con roles distintos (tanque, soporte y daño).', ephemeral: true });
+  }
+  session.state = 'ACTIVE';
+  await prisma.raid.update({ where: { id: session.raidId }, data: { state: 'ACTIVE' } });
+  await interaction.update({ components: [], embeds: [buildLobbyEmbed(session)] });
+  await interaction.followUp({ content: '¡La raid comienza!', ephemeral: true });
+  await sendNextPrompt(session, interaction);
+}
+
+async function handleAction(session: RaidSession, interaction: ButtonInteraction, role: RaidRole) {
+  if (session.state !== 'ACTIVE' || !session.prompt) {
+    return interaction.reply({ content: 'No hay ninguna mecánica activa.', ephemeral: true });
+  }
+  const member = session.members.get(interaction.user.id);
+  if (!member) {
+    return interaction.reply({ content: 'No formas parte de esta raid.', ephemeral: true });
+  }
+  if (member.down) {
+    return interaction.reply({ content: 'Estás incapacitado. Espera un revivir.', ephemeral: true });
+  }
+  if (session.prompt.responders.has(interaction.user.id)) {
+    return interaction.reply({ content: 'Ya respondiste a esta mecánica.', ephemeral: true });
+  }
+  session.prompt.responders.add(interaction.user.id);
+  const required = MECHANIC_ROLE[session.prompt.mechanic];
+  if (required !== role) {
+    await resolvePrompt(session, false, member, `${ROLE_LABELS[role]} intentó resolver pero falló.`);
+    return interaction.reply({ content: 'No era tu mecánica. ¡Tu error provoca un fallo!', ephemeral: true });
+  }
+  await resolvePrompt(session, true, member, 'Mecánica resuelta.');
+  return interaction.reply({ content: '¡Perfecto timing!', ephemeral: true });
+}
+
+async function handleRevive(session: RaidSession, interaction: ButtonInteraction) {
+  if (session.state !== 'ACTIVE') {
+    return interaction.reply({ content: 'La raid no está activa.', ephemeral: true });
+  }
+  const member = session.members.get(interaction.user.id);
+  if (!member || member.role !== 'support') {
+    return interaction.reply({ content: 'Solo un soporte puede usar el revivir.', ephemeral: true });
+  }
+  const now = Date.now();
+  if (member.reviveAvailableAt > now) {
+    const remaining = Math.ceil((member.reviveAvailableAt - now) / 1000);
+    return interaction.reply({ content: `Aún faltan ${remaining}s para poder revivir de nuevo.`, ephemeral: true });
+  }
+  const revived = Array.from(session.members.values()).filter((m) => m.down);
+  if (!revived.length) {
+    return interaction.reply({ content: 'Nadie necesita ser revivido.', ephemeral: true });
+  }
+  for (const m of revived) {
+    m.down = false;
+  }
+  member.reviveAvailableAt = now + REVIVE_COOLDOWN;
+  if (session.thread) {
+    await session.thread.send(`✨ <@${interaction.user.id}> revive a los aliados caídos.`);
+  }
+  return interaction.reply({ content: 'Aliados revividos.', ephemeral: true });
+}
+
+export default {
+  data: new SlashCommandBuilder().setName('raid').setDescription('Organiza una incursión cooperativa en un hilo.'),
+  ns: 'raid',
+  async execute(interaction: ChatInputCommandInteraction) {
+    const uid = interaction.user.id;
+    const user = await prisma.user.findUnique({ where: { id: uid } });
+    if (!user) {
+      return interaction.reply({ content: 'Debes usar `/start` antes de participar en raids.', ephemeral: true });
+    }
+    if (getSessionByUser(uid)) {
+      return interaction.reply({ content: 'Ya estás en una raid activa.', ephemeral: true });
+    }
+    await createRaid(interaction, uid);
+  },
+  async handleInteraction(interaction: ButtonInteraction) {
+    if (!interaction.isButton()) return;
+    const [ns, action, sessionId, value] = interaction.customId.split(':');
+    if (ns !== 'raid' || !sessionId) return;
+    const session = raidSessions.get(sessionId);
+    if (!session) {
+      return interaction.reply({ content: 'Esta raid ya terminó.', ephemeral: true });
+    }
+    if (!session.thread) {
+      session.thread = interaction.channel as ThreadChannel;
+    }
+    switch (action) {
+      case 'join':
+        if (value === 'damage' || value === 'support' || value === 'tank') {
+          await handleJoin(session, interaction, value);
+        }
+        break;
+      case 'leave':
+        await handleLeave(session, interaction);
+        break;
+      case 'cancel':
+        await handleCancel(session, interaction);
+        break;
+      case 'start':
+        await handleStart(session, interaction);
+        break;
+      case 'act':
+        if (value === 'damage' || value === 'support' || value === 'tank') {
+          await handleAction(session, interaction, value);
+        }
+        break;
+      case 'revive':
+        await handleRevive(session, interaction);
+        break;
+      default:
+        break;
+    }
+  },
+};

--- a/src/commands/rpg/skills.ts
+++ b/src/commands/rpg/skills.ts
@@ -1,0 +1,141 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+} from 'discord.js';
+import { prisma } from '../../lib/db.js';
+import {
+  AttributeKey,
+  BASE_ATTRIBUTES,
+  buildAttributeSummary,
+} from '../../services/progression.js';
+
+const ATTRIBUTE_LABELS: Record<AttributeKey, { name: string; description: string }> = {
+  strength: { name: 'Fuerza', description: 'Aumenta el daño base y la capacidad de llevar armaduras pesadas.' },
+  agility: { name: 'Agilidad', description: 'Mejora la evasión y los críticos rápidos.' },
+  intellect: { name: 'Intelecto', description: 'Potencia habilidades mágicas y escudos.' },
+  luck: { name: 'Suerte', description: 'Incrementa probabilidad de críticos y botín.' },
+};
+
+const RESPEC_COST = 750;
+
+function formatAttributes(user: any) {
+  return Object.entries(ATTRIBUTE_LABELS)
+    .map(([key, meta]) => `**${meta.name}:** ${user[key as AttributeKey]} · ${meta.description}`)
+    .join('\n');
+}
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('skills')
+    .setDescription('Consulta y asigna puntos de habilidad.')
+    .addSubcommand((sub) =>
+      sub.setName('ver').setDescription('Muestra tus atributos y puntos disponibles.'),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('asignar')
+        .setDescription('Asigna puntos a un atributo.')
+        .addStringOption((opt) =>
+          opt
+            .setName('atributo')
+            .setDescription('Atributo a mejorar.')
+            .setRequired(true)
+            .addChoices(
+              { name: 'Fuerza', value: 'strength' },
+              { name: 'Agilidad', value: 'agility' },
+              { name: 'Intelecto', value: 'intellect' },
+              { name: 'Suerte', value: 'luck' },
+            ),
+        )
+        .addIntegerOption((opt) =>
+          opt
+            .setName('puntos')
+            .setDescription('Cantidad de puntos a asignar.')
+            .setRequired(true)
+            .setMinValue(1),
+        ),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('respec')
+        .setDescription('Reinicia tus atributos a cambio de V Coins.'),
+    ),
+  ns: 'skills',
+  async execute(interaction: ChatInputCommandInteraction) {
+    const uid = interaction.user.id;
+    const sub = interaction.options.getSubcommand();
+
+    const user = await prisma.user.findUnique({ where: { id: uid } });
+    if (!user) {
+      return interaction.reply({ content: 'Debes usar `/start` primero.', ephemeral: true });
+    }
+
+    if (sub === 'ver') {
+      const embed = new EmbedBuilder()
+        .setTitle('Atributos y habilidades')
+        .setDescription(buildAttributeSummary(user))
+        .addFields(
+          { name: 'Puntos disponibles', value: `${user.skillPoints}`, inline: true },
+          { name: 'Sinergias', value: formatAttributes(user), inline: false },
+        )
+        .setColor(0x1abc9c);
+      return interaction.reply({ embeds: [embed], ephemeral: true });
+    }
+
+    if (sub === 'asignar') {
+      const attribute = interaction.options.getString('atributo', true) as AttributeKey;
+      const points = interaction.options.getInteger('puntos', true);
+      if (user.skillPoints < points) {
+        return interaction.reply({ content: 'No tienes suficientes puntos de habilidad.', ephemeral: true });
+      }
+
+      const stats = user as any;
+      const currentValue = Number(stats[attribute] ?? 0);
+      const newValue = currentValue + points;
+      await prisma.user.update({
+        where: { id: uid },
+        data: {
+          [attribute]: newValue,
+          skillPoints: { decrement: points },
+        },
+      });
+
+      return interaction.reply({
+        content: `Asignaste ${points} punto(s) a **${ATTRIBUTE_LABELS[attribute].name}**.`,
+        ephemeral: true,
+      });
+    }
+
+    if (sub === 'respec') {
+      if (user.vcoins < RESPEC_COST) {
+        return interaction.reply({ content: `Necesitas ${RESPEC_COST} V Coins para hacer respec.`, ephemeral: true });
+      }
+
+      let refunded = user.skillPoints;
+      const stats = user as any;
+      for (const [key, base] of Object.entries(BASE_ATTRIBUTES)) {
+        const attrKey = key as AttributeKey;
+        const currentValue = Number(stats[attrKey] ?? base);
+        refunded += Math.max(0, currentValue - base);
+      }
+
+      await prisma.user.update({
+        where: { id: uid },
+        data: {
+          vcoins: { decrement: RESPEC_COST },
+          strength: BASE_ATTRIBUTES.strength,
+          agility: BASE_ATTRIBUTES.agility,
+          intellect: BASE_ATTRIBUTES.intellect,
+          luck: BASE_ATTRIBUTES.luck,
+          skillPoints: refunded,
+        },
+      });
+
+      return interaction.reply({
+        content: `Reseteaste tus atributos. Puntos disponibles: ${refunded}. (-${RESPEC_COST} V Coins)`,
+        ephemeral: true,
+      });
+    }
+  },
+};

--- a/src/deploy-commands.ts
+++ b/src/deploy-commands.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
 
 async function loadSlashJson(): Promise<any[]> {
   const commands: any[] = [];
-  const cmdDirs = ['commands/core','commands/shop','commands/inventory','commands/economy'];
+  const cmdDirs = ['commands/core','commands/shop','commands/inventory','commands/economy','commands/rpg'];
   for (const dir of cmdDirs) {
     const full = path.join(process.cwd(), 'src', dir);
     if (!fs.existsSync(full)) continue;

--- a/src/register.ts
+++ b/src/register.ts
@@ -6,7 +6,8 @@ const CMD_DIRS = [
   'commands/core',
   'commands/shop',
   'commands/inventory',
-  'commands/economy'
+  'commands/economy',
+  'commands/rpg'
 ];
 
 export async function registerAllCommands(collection: Collection<string, any>) {

--- a/src/services/boss.ts
+++ b/src/services/boss.ts
@@ -1,0 +1,80 @@
+import { prisma } from '../lib/db.js';
+import { buildPlayerCombatant } from './combat.js';
+import { grantExperience } from './progression.js';
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+const BOSS_ROTATION = [
+  { key: 'titan_ferreo', name: 'Titán Férrero', baseHp: 20000, attack: 220, defense: 60 },
+  { key: 'reina_astral', name: 'Reina Astral', baseHp: 23000, attack: 200, defense: 75 },
+  { key: 'devorador', name: 'Devorador del Vacío', baseHp: 26000, attack: 250, defense: 70 },
+];
+
+export function getCurrentRotationWeek(timestamp = Date.now()) {
+  return Math.floor(timestamp / WEEK_MS);
+}
+
+export async function ensureWeeklyBoss() {
+  const rotationWeek = getCurrentRotationWeek();
+  let boss = await prisma.boss.findUnique({ where: { rotationWeek } });
+  if (boss) return boss;
+
+  const template = BOSS_ROTATION[rotationWeek % BOSS_ROTATION.length];
+  boss = await prisma.boss.create({
+    data: {
+      name: template.name,
+      rotationWeek,
+      hp: template.baseHp,
+      maxHp: template.baseHp,
+      metadata: { key: template.key, attack: template.attack, defense: template.defense },
+    },
+  });
+  return boss;
+}
+
+export async function getBossWithDamage() {
+  const boss = await ensureWeeklyBoss();
+  const damages = await prisma.bossDamage.findMany({
+    where: { bossId: boss.id },
+    orderBy: { damage: 'desc' },
+    take: 10,
+    include: { user: true },
+  });
+  return { boss, damages };
+}
+
+function computeBossDamage(playerAttack: number, bossDefense: number) {
+  const mitigated = playerAttack - bossDefense * 0.35;
+  return Math.max(5, Math.round(mitigated));
+}
+
+export async function attackBoss(userId: string) {
+  const boss = await ensureWeeklyBoss();
+  if (boss.hp <= 0) {
+    return { boss, damage: 0, defeated: true } as const;
+  }
+
+  const template = BOSS_ROTATION[boss.rotationWeek % BOSS_ROTATION.length];
+  const player = await buildPlayerCombatant(userId);
+  if (!player) throw new Error('Usuario inexistente.');
+
+  const damage = computeBossDamage(player.attack + (player.strength ?? 0) * 2, template.defense);
+  const critChance = Math.min(0.55, player.critChance + player.luck * 0.02);
+  const crit = Math.random() < critChance;
+  const dealt = crit ? Math.round(damage * 1.7) : damage;
+
+  const hp = Math.max(0, boss.hp - dealt);
+  const updated = await prisma.boss.update({ where: { id: boss.id }, data: { hp } });
+
+  await prisma.bossDamage.upsert({
+    where: { bossId_userId: { bossId: boss.id, userId } },
+    create: { bossId: boss.id, userId, damage: dealt },
+    update: { damage: { increment: dealt }, lastAttackAt: new Date() },
+  });
+
+  await prisma.user.update({ where: { id: userId }, data: { vcoins: { increment: Math.round(dealt / 10) } } });
+  await grantExperience(userId, Math.max(10, Math.round(dealt / 5)));
+
+  return { boss: updated, damage: dealt, crit, defeated: hp <= 0 } as const;
+}
+

--- a/src/services/combat.ts
+++ b/src/services/combat.ts
@@ -1,0 +1,338 @@
+import { Collection } from 'discord.js';
+import { prisma } from '../lib/db.js';
+import { computeBonusDamage, computeCritChance, computeDodgeChance } from './progression.js';
+
+export interface CombatSkill {
+  id: string;
+  name: string;
+  description: string;
+  cooldown: number;
+  execute: (ctx: SkillContext) => SkillResult;
+}
+
+export interface SkillContext {
+  player: CombatantState;
+  enemy: CombatantState;
+  turn: number;
+}
+
+export interface SkillResult {
+  damage: number;
+  critChanceBonus?: number;
+  shield?: number;
+  selfHeal?: number;
+  recoil?: number;
+}
+
+export interface CombatantState {
+  name: string;
+  hp: number;
+  hpMax: number;
+  attack: number;
+  defense: number;
+  strength?: number;
+  intellect: number;
+  agility: number;
+  luck: number;
+  critChance: number;
+  dodgeChance: number;
+}
+
+export interface BattleState {
+  id: string;
+  userId: string;
+  enemyId: number;
+  turn: number;
+  player: CombatantState & { cooldowns: Record<string, number>; shield: number };
+  enemy: CombatantState;
+  rewards: {
+    xp: number;
+    vcoins: { min: number; max: number };
+    name: string;
+  };
+  log: string[];
+  active: boolean;
+  messageId?: string;
+  channelId?: string;
+  createdAt: number;
+}
+
+function round(num: number) {
+  return Math.round(num * 100) / 100;
+}
+
+export const SKILL_DEFS: CombatSkill[] = [
+  {
+    id: 'quick_strike',
+    name: 'Golpe Rápido',
+    description: 'Ataque ágil con mayor probabilidad de crítico.',
+    cooldown: 0,
+    execute: ({ player }) => {
+      return {
+        damage: player.attack * 1.0 + (player.strength ?? 0) * 1.5 + player.agility * 0.5,
+        critChanceBonus: 0.1 + player.agility * 0.005,
+      };
+    },
+  },
+  {
+    id: 'power_strike',
+    name: 'Impacto Brutal',
+    description: 'Golpe devastador con breve enfriamiento. Reduce tu defensa temporalmente.',
+    cooldown: 1,
+    execute: ({ player }) => {
+      return {
+        damage: player.attack * 1.6 + computeBonusDamage(player.strength ?? 0, player.intellect * 0.5),
+        recoil: 0.15,
+      };
+    },
+  },
+  {
+    id: 'guard_focus',
+    name: 'Guardia Focalizada',
+    description: 'Reduce el daño recibido este turno y contraataca levemente.',
+    cooldown: 1,
+    execute: ({ player }) => {
+      return {
+        damage: player.attack * 0.6,
+        shield: 10 + player.intellect * 2 + player.agility,
+      };
+    },
+  },
+  {
+    id: 'arcane_burst',
+    name: 'Descarga Arcana',
+    description: 'Descarga mágica basada en tu intelecto que puede aplicar crítico alto.',
+    cooldown: 2,
+    execute: ({ player }) => {
+      return {
+        damage: player.intellect * 3 + (player.strength ?? 0) + player.attack * 0.4,
+        critChanceBonus: 0.2 + player.luck * 0.01,
+      };
+    },
+  },
+];
+
+export const battleStore = new Collection<string, BattleState>();
+
+export async function buildPlayerCombatant(userId: string): Promise<CombatantState | null> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    include: {
+      items: {
+        include: {
+          item: true,
+        },
+      },
+    },
+  });
+  if (!user) return null;
+
+  const weapon = user.equippedWeaponId
+    ? await prisma.item.findUnique({ where: { id: user.equippedWeaponId } })
+    : null;
+  const armor = user.equippedArmorId
+    ? await prisma.item.findUnique({ where: { id: user.equippedArmorId } })
+    : null;
+
+  const weaponPower = weapon?.power ?? 0;
+  const armorPower = armor?.power ?? 0;
+
+  const attack = user.attack + weaponPower + user.strength * 2 + Math.floor(user.agility * 0.5);
+  const defense = user.defense + armorPower + Math.floor(user.strength * 0.8) + Math.floor(user.agility * 0.3);
+  const intellect = user.intellect;
+  const agility = user.agility;
+  const luck = user.luck;
+
+  const hpMax = user.healthMax + armorPower * 5 + user.strength * 4 + user.intellect * 2;
+  const hp = Math.max(1, Math.min(hpMax, user.health));
+
+  return {
+    name: 'Tú',
+    hp,
+    hpMax,
+    attack,
+    defense,
+    strength: user.strength,
+    intellect,
+    agility,
+    luck,
+    critChance: computeCritChance(0.1 + (weaponPower > 0 ? 0.05 : 0), luck),
+    dodgeChance: computeDodgeChance(agility),
+  };
+}
+
+export interface MonsterCombatant {
+  monsterId: number;
+  state: CombatantState;
+  xpReward: number;
+  vcoinsMin: number;
+  vcoinsMax: number;
+  name: string;
+}
+
+export async function buildMonsterCombatant(): Promise<MonsterCombatant | null> {
+  const monsters = await prisma.monster.findMany({});
+  if (!monsters.length) return null;
+  const pick = monsters[Math.floor(Math.random() * monsters.length)];
+  const hpMax = pick.hp;
+  const attack = pick.attack;
+  const defense = pick.defense;
+  return {
+    monsterId: pick.id,
+    state: {
+      name: pick.name,
+      hp: hpMax,
+      hpMax,
+      attack,
+      defense,
+      strength: Math.max(1, pick.level),
+      intellect: Math.max(1, Math.floor(pick.level / 2)),
+      agility: Math.max(1, Math.floor(pick.level / 2)),
+      luck: Math.max(1, Math.floor(pick.level / 3)),
+      critChance: Math.min(0.35, pick.critChance + 0.02 * pick.level),
+      dodgeChance: Math.min(0.2, 0.01 * pick.level),
+    },
+    xpReward: pick.xpReward,
+    vcoinsMin: pick.vcoinsMin,
+    vcoinsMax: pick.vcoinsMax,
+    name: pick.name,
+  };
+}
+
+function applyDamage(attack: number, defense: number) {
+  const mitigated = attack - defense * 0.4;
+  return Math.max(1, Math.round(mitigated));
+}
+
+export function createBattleState(opts: {
+  userId: string;
+  player: CombatantState;
+  enemy: CombatantState;
+  enemyId: number;
+  rewards: { xp: number; vcoinsMin: number; vcoinsMax: number; name: string };
+}): BattleState {
+  const id = `${Date.now()}-${Math.floor(Math.random() * 9999)}`;
+  const state: BattleState = {
+    id,
+    userId: opts.userId,
+    enemyId: opts.enemyId,
+    turn: 1,
+    player: { ...opts.player, cooldowns: {}, shield: 0 },
+    enemy: { ...opts.enemy },
+    rewards: { xp: opts.rewards.xp, vcoins: { min: opts.rewards.vcoinsMin, max: opts.rewards.vcoinsMax }, name: opts.rewards.name },
+    log: ['⚔️ ¡La batalla comienza!'],
+    active: true,
+    createdAt: Date.now(),
+  };
+  battleStore.set(id, state);
+  return state;
+}
+
+export function describeBattle(state: BattleState) {
+  const { player, enemy } = state;
+  return {
+    title: `Turno ${state.turn}`,
+    playerLine: `❤️ ${player.hp}/${player.hpMax} · 🛡️ ${round(player.defense)} · Crit ${(player.critChance * 100).toFixed(0)}%`,
+    enemyLine: `❤️ ${enemy.hp}/${enemy.hpMax} · 🛡️ ${round(enemy.defense)} · Crit ${(enemy.critChance * 100).toFixed(0)}%`,
+    log: state.log.slice(-5).join('\n'),
+  };
+}
+
+export function runPlayerSkill(state: BattleState, skillId: string) {
+  if (!state.active) {
+    throw new Error('La batalla ya finalizó.');
+  }
+  const skill = SKILL_DEFS.find((s) => s.id === skillId);
+  if (!skill) {
+    throw new Error('Habilidad desconocida.');
+  }
+  const currentCd = state.player.cooldowns[skill.id] ?? 0;
+  if (currentCd > 0) {
+    throw new Error('La habilidad aún está en cooldown.');
+  }
+
+  const result = skill.execute({ player: state.player, enemy: state.enemy, turn: state.turn });
+  const critChance = Math.min(0.75, state.player.critChance + (result.critChanceBonus ?? 0));
+  const isCrit = Math.random() < critChance;
+  let damage = applyDamage(result.damage, state.enemy.defense);
+  if (isCrit) {
+    damage = Math.round(damage * (1.5 + state.player.luck * 0.02));
+  }
+  state.enemy.hp = Math.max(0, state.enemy.hp - damage);
+  state.log.push(`🗡️ Usas **${skill.name}** y causas ${damage} de daño${isCrit ? ' crítico' : ''}.`);
+
+  if (result.shield) {
+    state.player.shield = Math.round(result.shield);
+    state.log.push(`🛡️ Ganas un escudo de ${state.player.shield}.`);
+  } else {
+    state.player.shield = 0;
+  }
+  if (result.selfHeal) {
+    state.player.hp = Math.min(state.player.hpMax, state.player.hp + Math.round(result.selfHeal));
+    state.log.push('💚 Recuperas salud.');
+  }
+  if (result.recoil) {
+    const loss = Math.round(state.player.defense * result.recoil);
+    state.player.defense = Math.max(1, state.player.defense - loss);
+    state.log.push('⚠️ Tu defensa baja temporalmente.');
+  }
+
+  if (state.enemy.hp <= 0) {
+    state.active = false;
+    state.log.push('🎉 ¡Victoria!');
+  }
+
+  if (skill.cooldown > 0) {
+    state.player.cooldowns[skill.id] = skill.cooldown + 1;
+  }
+
+  // reduce cooldowns at end of turn
+  for (const key of Object.keys(state.player.cooldowns)) {
+    state.player.cooldowns[key] = Math.max(0, state.player.cooldowns[key] - 1);
+  }
+
+  return { damage, isCrit };
+}
+
+export function enemyTurn(state: BattleState) {
+  if (!state.active) return null;
+  state.turn += 1;
+
+  const enemy = state.enemy;
+  const player = state.player;
+
+  // enemy attack
+  const miss = Math.random() < player.dodgeChance;
+  if (miss) {
+    state.log.push(`${enemy.name} falla su ataque.`);
+    return { damage: 0, missed: true };
+  }
+
+  let dmg = applyDamage(enemy.attack, player.defense);
+  const crit = Math.random() < enemy.critChance;
+  if (crit) {
+    dmg = Math.round(dmg * 1.4);
+  }
+
+  if (player.shield > 0) {
+    const blocked = Math.min(player.shield, dmg);
+    dmg -= blocked;
+    player.shield = Math.max(0, player.shield - blocked);
+    state.log.push(`🛡️ Tu escudo bloquea ${blocked} de daño.`);
+  }
+
+  player.hp = Math.max(0, player.hp - dmg);
+  state.log.push(`${enemy.name} te golpea por ${dmg} de daño${crit ? ' crítico' : ''}.`);
+
+  if (player.hp <= 0) {
+    state.active = false;
+    state.log.push('💀 Has sido derrotado.');
+  }
+
+  return { damage: dmg, crit };
+}
+
+export function cleanupBattle(battleId: string) {
+  battleStore.delete(battleId);
+}
+

--- a/src/services/progression.ts
+++ b/src/services/progression.ts
@@ -1,0 +1,87 @@
+import { prisma } from '../lib/db.js';
+
+export const BASE_ATTRIBUTES = {
+  strength: 1,
+  agility: 1,
+  intellect: 1,
+  luck: 1,
+} as const;
+
+export type AttributeKey = keyof typeof BASE_ATTRIBUTES;
+
+export function xpToNext(level: number) {
+  return Math.max(50, level * level * 100);
+}
+
+export async function grantExperience(userId: string, amount: number) {
+  if (amount <= 0) {
+    return null;
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      xp: true,
+      level: true,
+      skillPoints: true,
+    },
+  });
+
+  if (!user) return null;
+
+  let { xp, level, skillPoints } = user;
+  xp += amount;
+  let levelsGained = 0;
+  let skillPointsEarned = 0;
+
+  while (xp >= xpToNext(level)) {
+    xp -= xpToNext(level);
+    level += 1;
+    levelsGained += 1;
+    skillPointsEarned += 3;
+  }
+
+  if (levelsGained > 0) {
+    skillPoints += skillPointsEarned;
+  }
+
+  await prisma.user.update({
+    where: { id: userId },
+    data: {
+      xp,
+      level,
+      skillPoints,
+    },
+  });
+
+  return {
+    xp,
+    level,
+    skillPoints,
+    levelsGained,
+    skillPointsEarned,
+  };
+}
+
+export function buildAttributeSummary(user: {
+  strength: number;
+  agility: number;
+  intellect: number;
+  luck: number;
+}) {
+  return `💪 Fuerza: ${user.strength}\n🏹 Agilidad: ${user.agility}\n✨ Intelecto: ${user.intellect}\n🍀 Suerte: ${user.luck}`;
+}
+
+export function computeCritChance(base: number, luck: number) {
+  const extra = luck * 0.01;
+  return Math.min(0.6, base + extra);
+}
+
+export function computeDodgeChance(agility: number) {
+  return Math.min(0.35, 0.02 + agility * 0.005);
+}
+
+export function computeBonusDamage(strength: number, intellect: number) {
+  return strength * 2 + intellect;
+}
+


### PR DESCRIPTION
## Summary
- add `/adventure`, `/battle`, `/boss`, `/raid`, and `/skills` commands covering exploration events, turn-based combat, weekly bosses, cooperative raids, and attribute management
- extend combat/progression services and database schema with skill points, core attributes, boss rotation, and raid tracking to support the new systems
- update command registration/deployment and profile output to expose the new gameplay features

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2f672baf8832ba8c1bffa4e9adaa5